### PR TITLE
Modified p5-basic sketch and ProcessingOSC to send and receive

### DIFF
--- a/bridge.js
+++ b/bridge.js
@@ -1,5 +1,5 @@
 var osc = require('node-osc'),
-    io = require('socket.io').listen(8081);
+    io = require('socket.io').listen(8085);
 
 var oscServer, oscClient;
 

--- a/bridge.js
+++ b/bridge.js
@@ -1,5 +1,5 @@
 var osc = require('node-osc'),
-    io = require('socket.io').listen(8085);
+    io = require('socket.io').listen(8081);
 
 var oscServer, oscClient;
 

--- a/p5-basic/ProcessingOSC/ProcessingOSC.pde
+++ b/p5-basic/ProcessingOSC/ProcessingOSC.pde
@@ -1,33 +1,60 @@
 /**
- this Processing sketch will send its mouse
- position over OSC to the p5.js sketch in the folder "p5-basic".
+ This Processing sketch will send its mouse position 
+ over OSC to the p5.js sketch in the folder "p5-basic".
  you need the library OscP5 to run it.
+ 
+ It will also receive the mouse position from the p5.js sketch 
+ and display it on the screen.
  */
  
 import oscP5.*;
 import netP5.*;
+int x,y;
 
 OscP5 oscP5;
 NetAddress myRemoteLocation;
 
 void setup() {
   size(500, 500);
-  oscP5 = new OscP5(this, 8000);
-  myRemoteLocation = new NetAddress("127.0.0.1", 12000);
+  // Start OSC and listen for messages on port 3334
+  oscP5 = new OscP5(this, 3334);
+  // We'll send OSC messages on port 3333
+  myRemoteLocation = new NetAddress("127.0.0.1", 3333);
 }
 
 
 void draw() {
+
   background(0);
   fill(255);
-  ellipse(mouseX, mouseY, 100, 100);
+  ellipse(x, y, 100, 100);
   fill(0);
-  text("I'm Processing", mouseX-40, mouseY);
+  text("I'm Processing", x-40, y);
   
   // send mouse position over OSC
   OscMessage myMessage = new OscMessage("/test");
   myMessage.add(mouseX);
   myMessage.add(mouseY);
   oscP5.send(myMessage, myRemoteLocation);
+}
+
+// run whenever an OSC message is received
+void oscEvent(OscMessage theOscMessage) {
+  
+  // print the address  of the received message
+  print("### received an osc message.");
+  print(" address: "+theOscMessage.addrPattern());
+  //print(" typetag: "+theOscMessage.typetag());
+
+  // check if incoming message has the address you're looking for
+  if(theOscMessage.checkAddrPattern("/mousePos")==true){
+    // parse the x and y mouse coordinates from the message
+    x = theOscMessage.get(0).intValue();
+    y = theOscMessage.get(1).intValue();
+    print(" x: "+x + " y: "+y);
+  }
+
+  println();
+  
 }
 

--- a/p5-basic/index.html
+++ b/p5-basic/index.html
@@ -2,7 +2,7 @@
 
 <head>
   	<meta charset="UTF-8">
-	<script src="http://127.0.0.1:8085/socket.io/socket.io.js"></script>
+	<script src="http://127.0.0.1:8081/socket.io/socket.io.js"></script>
   	<script language="javascript" type="text/javascript" src="libraries/p5.js"></script>
   	<script language="javascript" type="text/javascript" src="osc.js"></script>
   	<script language="javascript" type="text/javascript" src="sketch.js"></script>

--- a/p5-basic/index.html
+++ b/p5-basic/index.html
@@ -2,8 +2,9 @@
 
 <head>
   	<meta charset="UTF-8">
-	<script src="http://127.0.0.1:8081/socket.io/socket.io.js"></script>
+	<script src="http://127.0.0.1:8085/socket.io/socket.io.js"></script>
   	<script language="javascript" type="text/javascript" src="libraries/p5.js"></script>
+  	<script language="javascript" type="text/javascript" src="osc.js"></script>
   	<script language="javascript" type="text/javascript" src="sketch.js"></script>
   	<style> body {padding: 0; margin: 0;} </style>
 </head>

--- a/p5-basic/osc.js
+++ b/p5-basic/osc.js
@@ -10,7 +10,7 @@ function sendOsc(address, value) {
   }
 
 function setupOsc(oscPortIn, oscPortOut) {
-	socket = io.connect('http://127.0.0.1', { port: 8085, forceNew: true, rememberTransport: false });
+	socket = io.connect('http://127.0.0.1', { port: 8081, forceNew: true, rememberTransport: false });
 	socket.on('connect', function() {
 		socket.emit('config', {	
 			server: { port: oscPortIn,  host: '127.0.0.1'},

--- a/p5-basic/osc.js
+++ b/p5-basic/osc.js
@@ -1,0 +1,30 @@
+var socket;
+var isConnected = false;
+
+function sendOsc(address, value) {
+  if (isConnected == true)
+  {
+ 	socket.emit('message', [address].concat(value));
+  }
+    
+  }
+
+function setupOsc(oscPortIn, oscPortOut) {
+	socket = io.connect('http://127.0.0.1', { port: 8085, forceNew: true, rememberTransport: false });
+	socket.on('connect', function() {
+		socket.emit('config', {	
+			server: { port: oscPortIn,  host: '127.0.0.1'},
+			client: { port: oscPortOut, host: '127.0.0.1'}
+		});
+    isConnected = true;
+	});
+	socket.on('message', function(msg) {
+		if (msg[0] == '#bundle') {
+			for (var i=2; i<msg.length; i++) {
+				receiveOsc(msg[i][0], msg[i].splice(1));
+			}
+		} else {
+			receiveOsc(msg[0], msg.splice(1));
+		}
+	});
+}

--- a/p5-basic/sketch.js
+++ b/p5-basic/sketch.js
@@ -1,45 +1,50 @@
-var x, y;
+/*
+This sketch receives mouse positions (i.e. [x,y] coordinates) 
+over OSC and displays it to screen
+It also sends out the current mouse position over OSC
+
+e.g. This can be used along with Processing sketch 'ProcessingOSC'
+to test OSC send and receive capabilities
+
+The sketch needs the osc.js script in the same folder and included in index.html
+
+Before running, you need to start node server by executing
+node bridge.js
+in the folder where 'bridge.js' is (should be one folder up)
+
+If you get the error 'Uncaught ReferenceError: io is not defined' on running this sketch,
+it means the node server isn't running or may have crashed.
+*/
+
+var connect_to_this_ip = '127.0.0.1'
+var incomingPort = 3333;
+var outgoingPort = 3334;
+
+var x = 250, y = 250;
 
 function setup() {
 	createCanvas(500, 500);
-	setupOsc(12000, 3334);
+	setupOsc(incomingPort, outgoingPort);
 }
 
 function draw() {
-	background(0, 0, 255);
-	fill(0, 255, 0);
+	background(0);
+	fill(255);
 	ellipse(x, y, 100, 100);
 	fill(0);
 	text("I'm p5.js", x-25, y);
+	
+	// Send mouse position over OSC
+	sendOsc('/mousePos',[mouseX,mouseY]);
 }
 
+// This is run every time an OSC message is received
 function receiveOsc(address, value) {
 	console.log("received OSC: " + address + ", " + value);
 	
+  // Change the code below depending on the form of the incoming OSC message	
 	if (address == '/test') {
 		x = value[0];
 		y = value[1];
 	}
 }
-
-function sendOsc(address, value) {
-	socket.emit('message', [address].concat(value));
-}
-
-function setupOsc(oscPortIn, oscPortOut) {
-	var socket = io.connect('http://127.0.0.1', { port: 8081, rememberTransport: false });
-	socket.on('connect', function() {
-		socket.emit('config', {	
-			server: { port: oscPortIn,  host: '127.0.0.1'},
-			client: { port: oscPortOut, host: '127.0.0.1'}
-		});
-	});
-	socket.on('message', function(msg) {
-		if (msg[0] == '#bundle') {
-			for (var i=2; i<msg.length; i++) {
-				receiveOsc(msg[i][0], msg[i].splice(1));
-			}
-		} else {
-			receiveOsc(msg[0], msg.splice(1));
-		}
-	});


### PR DESCRIPTION
Hi Gene,

I tested out the p5-basic sketch, and modified it so each sketch sends its mouse position, and draws at the mouse position received from the other sketch. This way we can quickly test send and receive at the same time with both sketches (p5 & Processing) open.

Some modifications I made:
- Added back the 'connected' variable because without it the P5 sketch was crashing on sending OSC
- Also, I think there was a missing curly brace at the end of the original sketch causing it to not run.
- Modified the processing and P5 sketches so that they're both sending and receiving mouse positions. 
- Added some comments
- Also, this is just an aesthetic thing, but to make the sketch more user friendly I hid away some of the functions that most users won't need to mess with in a file 'osc.js'

Tested it a bunch for reliability and it seems to work very well.

Feel free to include any of these changes if you like.

Cheers,
Aatish
